### PR TITLE
Remove noisy debug log for missing version

### DIFF
--- a/go/private/skylib/lib/versions.bzl
+++ b/go/private/skylib/lib/versions.bzl
@@ -94,10 +94,6 @@ def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, baze
   if not bazel_version:
     if "bazel_version" not in dir(native):
       fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" % minimum_bazel_version)
-    elif not native.bazel_version:
-      print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
-      print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
-      return
     else:
       bazel_version = native.bazel_version
 


### PR DESCRIPTION
Users that build bazel from source (perhaps because they want to pin the bazel version via a submodule or other means) will not have a bazel version present ever.

This means every single bazel command will print out the following debug lines, which are mostly noise, since those users are probably aware they have built bazel from source. 

>DEBUG: /private/var/tmp/_bazel_jgavris/c1e7067b81f8f6fa16df07b65cd39d9c/external/io_bazel_rules_go/go/private/skylib/lib/versions.bzl:98:7:
Current Bazel is not a release version, cannot check for compatibility.
DEBUG: /private/var/tmp/_bazel_jgavris/c1e7067b81f8f6fa16df07b65cd39d9c/external/io_bazel_rules_go/go/private/skylib/lib/versions.bzl:99:7: Make sure that you are running at least Bazel 0.8.0.